### PR TITLE
Fix end of systemd ExecStart command

### DIFF
--- a/templates/ustreamer.systemd.j2
+++ b/templates/ustreamer.systemd.j2
@@ -49,7 +49,9 @@ ExecStart={{ ustreamer_dir }}/ustreamer \
 {% if ustreamer_tcp_nodelay %}
   --tcp-nodelay \
 {% endif %}
-
+  && :
+# This last line is just to end the multi-line command because the line
+# before is ending with backslash and so expects to be continued.
 Restart=always
 
 [Install]


### PR DESCRIPTION
The systemd `ExecStart` command had an issue, was not ended correctly : the line after it `Restart=always` was actually included in the command.

We can't end the `ExecStart` command with an empty line as [empty lines are ignored by systemd](https://www.freedesktop.org/software/systemd/man/systemd.syntax.html) so I added a line that does nothing, just to end properly the multi-line command.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tiny-pilot/ansible-role-ustreamer/47)
<!-- Reviewable:end -->
