### PR TITLE
Add compatibility with Raspbian bullseye

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Ansible Role: µStreamer
 
-[![CircleCI](https://circleci.com/gh/mtlynch/ansible-role-ustreamer.svg?style=svg)](https://circleci.com/gh/mtlynch/ansible-role-ustreamer) [![Ansible Galaxy](https://img.shields.io/badge/ansible--galaxy-ustreamer-blue.svg?style=flat-square)](https://galaxy.ansible.com/mtlynch/ustreamer) [![License](http://img.shields.io/:license-mit-blue.svg?style=flat-square)](LICENSE)
+[![CircleCI](https://circleci.com/gh/tiny-pilot/ansible-role-ustreamer.svg?style=svg)](https://circleci.com/gh/tiny-pilot/ansible-role-ustreamer) [![Ansible Galaxy](https://img.shields.io/badge/ansible--galaxy-ustreamer-blue.svg?style=flat-square)](https://galaxy.ansible.com/mtlynch/ustreamer) [![License](http://img.shields.io/:license-mit-blue.svg?style=flat-square)](LICENSE)
 
 Ansible role for [µStreamer](https://github.com/pikvm/ustreamer).
 
@@ -18,7 +18,7 @@ ustreamer_repo: https://github.com/pikvm/ustreamer.git
 ustreamer_repo_version: master
 ```
 
-For a full list of options, see [defaults/main.yml](https://github.com/mtlynch/ansible-role-ustreamer/blob/master/defaults/main.yml).
+For a full list of options, see [defaults/main.yml](https://github.com/tiny-pilot/ansible-role-ustreamer/blob/master/defaults/main.yml).
 
 ## Dependencies
 
@@ -47,4 +47,4 @@ MIT
 
 ## Author Information
 
-This role was created in 2020 by [Michael Lynch](http://mtlynch.io).
+This role was created in 2020 by [TinyPilot](https://tinypilotkvm.com).

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Ansible Role: µStreamer
 
-[![CircleCI](https://circleci.com/gh/tiny-pilot/ansible-role-ustreamer.svg?style=svg)](https://circleci.com/gh/tiny-pilot/ansible-role-ustreamer) [![Ansible Galaxy](https://img.shields.io/badge/ansible--galaxy-ustreamer-blue.svg?style=flat-square)](https://galaxy.ansible.com/mtlynch/ustreamer) [![License](http://img.shields.io/:license-mit-blue.svg?style=flat-square)](LICENSE)
+[![CircleCI](https://circleci.com/gh/tiny-pilot/ansible-role-ustreamer.svg?style=svg)](https://circleci.com/gh/tiny-pilot/ansible-role-ustreamer) [![License](http://img.shields.io/:license-mit-blue.svg?style=flat-square)](LICENSE)
 
 Ansible role for [µStreamer](https://github.com/pikvm/ustreamer).
 
@@ -31,13 +31,13 @@ None
 ```yaml
 - hosts: all
   roles:
-    - role: mtlynch.ustreamer
+    - role: ansible-role-ustreamer
 ```
 
 ### Running Example Playbook
 
 ```bash
-ansible-galaxy install mtlynch.ustreamer
+ansible-galaxy install git+https://github.com/tiny-pilot/ansible-role-ustreamer.git
 ansible-playbook example.yml
 ```
 

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -11,6 +11,20 @@ platforms:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
     privileged: true
     pre_build_image: true
+  - name: debian10
+    image: geerlingguy/docker-debian10-ansible
+    command: ${MOLECULE_DOCKER_COMMAND:-""}
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    privileged: true
+    pre_build_image: true
+  - name: debian11
+    image: geerlingguy/docker-debian11-ansible
+    command: ${MOLECULE_DOCKER_COMMAND:-""}
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    privileged: true
+    pre_build_image: true
   - name: ubuntu20
     image: geerlingguy/docker-ubuntu1804-ansible
     command: ${MOLECULE_DOCKER_COMMAND:-""}


### PR DESCRIPTION
libjpeg8-dev is no longer available in raspbian bullseye default sources, and was replaced with libjpeg9-dev. the ustreamer install task fails unless this change is made.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tiny-pilot/ansible-role-ustreamer/48)
<!-- Reviewable:end -->
