### PR TITLE
Always build ustreamer

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -93,36 +93,22 @@
     repo: "{{ ustreamer_repo }}"
     dest: "{{ ustreamer_dir }}"
     version: "{{ ustreamer_repo_version }}"
-  register: ustreamer_repo_result
-  notify:
-    - restart uStreamer
 
-# We don't actually need this file for anything. It's just a canary to keep
-# track of when we need to clean the build because of a change in build options
-# since the last compilation.
-- name: cache build settings
-  template:
-    src: build-settings.j2
-    dest: "/home/{{ ustreamer_user }}/build-settings.cache"
-    owner: "{{ ustreamer_user }}"
-    group: "{{ ustreamer_group }}"
-    mode: '0644'
-  register: ustreamer_cache_build_settings_result
-
-- name: clean repository if needed
+# We always need to clean & build uStreamer to ensure that the uStreamer service
+# is in sync with its dependencies installed on the device.
+# Issue: https://github.com/tiny-pilot/ansible-role-tinypilot/issues/174
+- name: clean uStreamer repository
   make:
     chdir: "{{ ustreamer_dir }}"
     target: clean
-  when: ustreamer_repo_result.changed or ustreamer_cache_build_settings_result.changed
 
 - name: build uStreamer
   make:
     chdir: "{{ ustreamer_dir }}"
     params:
       WITH_OMX: "{{ ustreamer_enable_omx | int }}"
-  # TODO: We shouldn't have to set conditions on this, but it otherwise builds every time
-  # for some reason, and I can't figure out why.
-  when: ustreamer_repo_result.changed or ustreamer_cache_build_settings_result.changed
+  notify:
+    - restart uStreamer
 
 - name: fix uStreamer folder permissions
   file:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -101,6 +101,8 @@
   make:
     chdir: "{{ ustreamer_dir }}"
     target: clean
+  tags:
+    - molecule-idempotence-notest
 
 - name: build uStreamer
   make:
@@ -109,6 +111,8 @@
       WITH_OMX: "{{ ustreamer_enable_omx | int }}"
   notify:
     - restart uStreamer
+  tags:
+    - molecule-idempotence-notest
 
 - name: fix uStreamer folder permissions
   file:

--- a/templates/build-settings.j2
+++ b/templates/build-settings.j2
@@ -1,3 +1,0 @@
-# This is an auto-generated file managed by Ansible.
-
-enable_omx: {{ ustreamer_enable_omx }}


### PR DESCRIPTION
Fixes https://github.com/tiny-pilot/ansible-role-tinypilot/issues/174

### Note
In order to fix the original issue, we must rebuild uStreamer. We were already [caching the uStreamer build settings](https://github.com/tiny-pilot/ansible-role-ustreamer/blob/dd4983a307f7d78cdb74374d2e86dec998627fd2/tasks/main.yml#L100-L110) in an attempt to [conditionally rebuild uStreamer](https://github.com/tiny-pilot/ansible-role-ustreamer/blob/dd4983a307f7d78cdb74374d2e86dec998627fd2/tasks/main.yml#L125). Seeing as we have no easy way to detect if a device suffers from the bug, we must now always rebuild uStreamer. This means that the cached build settings file (`/home/ustreamer/build-settings.cache`) is no longer needed. This PR removes the creation of `build-settings.cache`, but that leaves an unmanaged `build-settings.cache` on the device indefinitely. As an alternative, we could either: 
1. Continue to create the file even though it's no longer needed.
1. Explicitly remove it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tiny-pilot/ansible-role-ustreamer/50)
<!-- Reviewable:end -->
