### PR TITLE
Increase CircleCI build instance resource class to large

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,6 +3,7 @@ jobs:
   build:
     machine:
       image: ubuntu-2004:202010-01
+    resource_class: large
     steps:
       - checkout
       - run:


### PR DESCRIPTION
There's also xlarge, which is 2x bigger, but in my experience, that actually results in slower builds because it takes 2-3 minutes to provision an xlarge machine.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tiny-pilot/ansible-role-ustreamer/53)
<!-- Reviewable:end -->
