### PR TITLE
Add H264 sink parameters

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -78,20 +78,19 @@ ustreamer_edid: |
 # Location to store EDID files.
 ustreamer_edids_dir: /home/{{ ustreamer_user }}/edids
 
-# Compile uStreamer with OpenMax IL hardware acceleration.
-ustreamer_compile_omx: no
-
 # Compile the uStreamer plugin for Janus WebRTC Server.
 ustreamer_compile_janus_plugin: no
 
 # H264 sink options are only available when OpenMax IL hardware acceleration is
-# enabled via the ustreamer_compile_omx variable.
+# enabled via the dynamically defined ustreamer_compile_omx variable.
 
-# Use the specified shared memory object to sink H264 frames encoded by MMAL.
+# Use the specified shared memory object to sink H264 frames encoded by MMAL
+# (e.g., tinypilot::ustreamer::h264). Disabled by default.
 ustreamer_h264_sink: null
 
-# Set H264 sink permissions, such as 777.
+# Set permissions bitmask for H264 shared memory object (e.g., 777). Defaults
+# to 660 when not set.
 ustreamer_h264_sink_mode: null
 
-# Remove shared memory on stop.
-ustreamer_h264_sink_rm: no
+# Remove shared memory on stop (e.g., yes). Defaults to no when not set.
+ustreamer_h264_sink_rm: null

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -78,5 +78,20 @@ ustreamer_edid: |
 # Location to store EDID files.
 ustreamer_edids_dir: /home/{{ ustreamer_user }}/edids
 
+# Compile uStreamer with OpenMax IL hardware acceleration.
+ustreamer_compile_omx: no
+
 # Compile the uStreamer plugin for Janus WebRTC Server.
 ustreamer_compile_janus_plugin: no
+
+# H264 sink options are only available when OpenMax IL hardware acceleration is
+# enabled via the ustreamer_compile_omx variable.
+
+# Use the specified shared memory object to sink H264 frames encoded by MMAL.
+ustreamer_h264_sink: null
+
+# Set H264 sink permissions, such as 777.
+ustreamer_h264_sink_mode: null
+
+# Remove shared memory on stop.
+ustreamer_h264_sink_rm: no

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -43,10 +43,6 @@
   set_fact:
     ustreamer_is_os_raspbian: "{{ ansible_lsb.id is defined and ansible_lsb.id == 'Raspbian' }}"
 
-- name: enable OpenMax IL acceleration on Pi OS
-  set_fact:
-    ustreamer_enable_omx: "{{ ustreamer_is_os_raspbian and ustreamer_encoder != None and ustreamer_encoder.lower() == 'omx' }}"
-
 - name: collect universal required apt packages
   set_fact:
     ustreamer_packages:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -60,7 +60,7 @@
 - name: install libraspberrypi-dev if we're using OpenMax IL acceleration
   set_fact:
     ustreamer_packages: "{{ ustreamer_packages }} + ['libraspberrypi-dev']"
-  when: ustreamer_enable_omx
+  when: ustreamer_compile_omx
 
 - name: collect Debian-specific required apt packages
   set_fact:
@@ -109,7 +109,7 @@
   make:
     chdir: "{{ ustreamer_dir }}"
     params:
-      WITH_OMX: "{{ ustreamer_enable_omx | int }}"
+      WITH_OMX: "{{ ustreamer_compile_omx | int }}"
       WITH_JANUS: "{{ ustreamer_compile_janus_plugin | int }}"
   notify:
     - restart uStreamer

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,4 +1,14 @@
 ---
+- name: check that the H264 variables are in a consistent state
+  fail:
+    msg: >-
+      The H264 variables are in an inconsistent state. You must set the
+      ustreamer_h264_sink variable in order to set other H264 variables.
+  when: >-
+    ustreamer_h264_sink == None
+    and (ustreamer_h264_sink_mode != None
+         or ustreamer_h264_sink_rm != None)
+
 - name: create ustreamer group
   group:
     name: "{{ ustreamer_group }}"
@@ -42,6 +52,14 @@
 - name: save whether boot config file exists
   set_fact:
     ustreamer_is_os_raspbian: "{{ ansible_lsb.id is defined and ansible_lsb.id == 'Raspbian' }}"
+
+- name: enable OpenMax IL acceleration on Pi OS
+  set_fact:
+    ustreamer_compile_omx: >-
+      {{ ustreamer_h264_sink != None
+         or (ustreamer_is_os_raspbian
+             and ustreamer_encoder != None
+             and ustreamer_encoder.lower() == 'omx') }}
 
 - name: collect universal required apt packages
   set_fact:

--- a/templates/ustreamer.systemd.j2
+++ b/templates/ustreamer.systemd.j2
@@ -49,6 +49,15 @@ ExecStart={{ ustreamer_dir }}/ustreamer \
 {% if ustreamer_tcp_nodelay %}
   --tcp-nodelay \
 {% endif %}
+{% if ustreamer_h264_sink %}
+  --h264-sink {{ ustreamer_h264_sink }} \
+{% endif %}
+{% if ustreamer_h264_sink_mode %}
+  --h264-sink-mode {{ ustreamer_h264_sink_mode }} \
+{% endif %}
+{% if ustreamer_h264_sink_rm %}
+  --h264-sink-rm \
+{% endif %}
   && :
 # This last line is just to end the multi-line command because the line
 # before is ending with backslash and so expects to be continued.


### PR DESCRIPTION
This PR is part of https://github.com/tiny-pilot/ansible-role-tinypilot/issues/179

In order to remove uStreamer from the H264 docker image, we need to allow the uStreamer running on the device to specify H264 memsink parameters.

### Note
 In order to make use of the H264 memsink, uStreamer has to be compiled with OpenMax IL hardware acceleration (OMX) enabled ([source](https://github.com/pikvm/ustreamer/blob/61ab2a81a50c2347685b9993ddf84d0833ca7cfa/man/ustreamer.1#L222-L224)). Currently, we only enable OMX when the encoder is set to `omx`. However, for the [Hobbyist device we use the `hw` encoder](https://github.com/tiny-pilot/tinypilot/blob/master/quick-install#L77) which results in uStreamer not compiling with omx and thus disabling the use of H264 memsink.
I have removed the dynamic `ustreamer_enable_omx` variable from the `tasks/main.yml` and [added it to `defaults/main.yml`](https://github.com/tiny-pilot/ansible-role-ustreamer/blob/1cc605f746b7614b6b41204df0bd462b90a83f2f/defaults/main.yml#L81-L82) where the user should set it explicitly. I've also renamed the variable `ustreamer_enable_omx` -> `ustreamer_compile_omx` to indicate that it's only a compilation flag and that uStreamer doesn't use OMX until you set the encoder as `omx`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tiny-pilot/ansible-role-ustreamer/54)
<!-- Reviewable:end -->
