### PR TITLE
Change directory owner before syncing git

### DIFF
--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -34,6 +34,11 @@ platforms:
     pre_build_image: true
 provisioner:
   name: ansible
+  inventory:
+    hosts:
+      all:
+        vars:
+          ansible_user: root
 verifier:
   name: ansible
 scenario:

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -34,6 +34,8 @@ platforms:
     pre_build_image: true
 provisioner:
   name: ansible
+  connection_options:
+    ansible_user: ansible
 verifier:
   name: ansible
 scenario:

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -34,8 +34,6 @@ platforms:
     pre_build_image: true
 provisioner:
   name: ansible
-  connection_options:
-    ansible_user: ansible
 verifier:
   name: ansible
 scenario:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -111,6 +111,11 @@
     owner: root
     group: root
     recurse: yes
+  tags:
+    # This fails the idempotency test because it is run on every provision to
+    # allow git to sync.
+    # Issue: https://github.com/tiny-pilot/tinypilot/issues/963
+    - molecule-idempotence-notest
 
 - name: get uStreamer repo
   git:
@@ -146,7 +151,6 @@
     owner: "{{ ustreamer_user }}"
     group: "{{ ustreamer_group }}"
     recurse: yes
-  # TODO: Figure out why this fails idempotency otherwise.
   tags:
     - molecule-idempotence-notest
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -125,6 +125,11 @@
     repo: "{{ ustreamer_repo }}"
     dest: "{{ ustreamer_dir }}"
     version: "{{ ustreamer_repo_version }}"
+  tags:
+    # This fails the idempotency test because we're also skipping the
+    # idempotency test on the previous task that allows git to sync.
+    # Issue: https://github.com/tiny-pilot/tinypilot/issues/963
+    - molecule-idempotence-notest
 
 # We always need to clean & build uStreamer to ensure that the uStreamer service
 # is in sync with its dependencies installed on the device.

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -108,8 +108,8 @@
   file:
     path: "{{ ustreamer_dir }}"
     state: directory
-    owner: root
-    group: root
+    owner: "{{ ansible_user }}"
+    group: "{{ ansible_user }}"
     recurse: yes
   tags:
     # This fails the idempotency test because it must run on every provision
@@ -118,15 +118,13 @@
     - molecule-idempotence-notest
 
 - name: get uStreamer repo
+  # Don't escalate privileges because only the directory owner can use git.
+  # Issue: https://github.com/tiny-pilot/tinypilot/issues/963
+  become: no
   git:
     repo: "{{ ustreamer_repo }}"
     dest: "{{ ustreamer_dir }}"
     version: "{{ ustreamer_repo_version }}"
-  tags:
-    # This fails the idempotency test because we're also skipping the
-    # idempotency test on the previous task that allows git to sync.
-    # Issue: https://github.com/tiny-pilot/tinypilot/issues/963
-    - molecule-idempotence-notest
 
 # We always need to clean & build uStreamer to ensure that the uStreamer service
 # is in sync with its dependencies installed on the device.

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -112,8 +112,8 @@
     group: root
     recurse: yes
   tags:
-    # This fails the idempotency test because it is run on every provision to
-    # allow git to sync.
+    # This fails the idempotency test because it must run on every provision
+    # to set the correct directory ownership that allows git to sync.
     # Issue: https://github.com/tiny-pilot/tinypilot/issues/963
     - molecule-idempotence-notest
 
@@ -122,6 +122,11 @@
     repo: "{{ ustreamer_repo }}"
     dest: "{{ ustreamer_dir }}"
     version: "{{ ustreamer_repo_version }}"
+  tags:
+    # This fails the idempotency test because we're also skipping the
+    # idempotency test on the previous task that allows git to sync.
+    # Issue: https://github.com/tiny-pilot/tinypilot/issues/963
+    - molecule-idempotence-notest
 
 # We always need to clean & build uStreamer to ensure that the uStreamer service
 # is in sync with its dependencies installed on the device.

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -108,8 +108,9 @@
   file:
     path: "{{ ustreamer_dir }}"
     state: directory
-    owner: "{{ ustreamer_user }}"
-    group: "{{ ustreamer_group }}"
+    owner: root
+    group: root
+    recurse: yes
 
 - name: get uStreamer repo
   git:


### PR DESCRIPTION
Part of https://github.com/tiny-pilot/tinypilot/issues/963

This is needed to allow git to sync after the announced [git security fix](https://github.blog/2022-04-12-git-security-vulnerability-announced/).

> By default, Git will refuse to even parse a Git config of a repository owned by someone else

Alternatively, we could bypass this new git behaviour by marking the git repo directory as a [`safe.directory`](https://git-scm.com/docs/git-config/2.35.2#Documentation/git-config.txt-safedirectory), but that would defeat the purpose of the security fix especially seeing as we can't assume the device is a single-user machine.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tiny-pilot/ansible-role-ustreamer/59)
<!-- Reviewable:end -->
