### PR TITLE
Use standardized `check-bash` script

### DIFF
--- a/tests/check-bash
+++ b/tests/check-bash
@@ -10,14 +10,17 @@ set -u
 
 BASH_SCRIPTS=()
 
-while read -r line; do
-  BASH_SCRIPTS+=("${line}")
-done < <(find . \
-  -not -path './\.*' \
-  -not -path './venv/*' \
-  -not -path './node_modules/*' \
-  -type f \
-  -exec bash -c 'head -n 1 $1 | grep --quiet "#!/bin/bash"' _ {} \; \
-  -print)
+while read -r filepath; do
+  if head -n 1 "${filepath}" | grep --quiet \
+    --regexp '#!/bin/bash' \
+    --regexp '#!/usr/bin/env bash' \
+    --regexp '#!/usr/sh' \
+    --regexp '#!/usr/bin/env sh' \
+    ; then
+      BASH_SCRIPTS+=("${filepath}")
+  fi
+done < <(git ls-files)
+
+readonly BASH_SCRIPTS
 
 shellcheck "${BASH_SCRIPTS[@]}"


### PR DESCRIPTION
Part of https://github.com/tiny-pilot/ansible-role-tinypilot-pro/issues/84: use “standardized” `check-bash` script, [as introduced here](https://github.com/tiny-pilot/ansible-role-tinypilot/pull/198).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tiny-pilot/ansible-role-ustreamer/60)
<!-- Reviewable:end -->
