### PR TITLE
Configure load-tc358743-edid service to restart on failure

### DIFF
--- a/templates/load-tc358743-edid.systemd.j2
+++ b/templates/load-tc358743-edid.systemd.j2
@@ -1,6 +1,9 @@
 [Unit]
 Description=Load EDID for TC358743 HDMI capture chip.
 After=syslog.target
+# Give up if we restart on failure 20 times within 5 minutes (300 seconds).
+StartLimitIntervalSec=300
+StartLimitBurst=10
 
 [Service]
 Type=oneshot
@@ -8,6 +11,7 @@ User=root
 ExecStart=v4l2-ctl \
   --set-edid=file={{ ustreamer_edids_dir }}/tc358743-edid.hex \
   --fix-edid-checksums
+Restart=on-failure
 
 [Install]
 WantedBy=local-fs.target


### PR DESCRIPTION
In testing TinyPilot on Debian Bullseye (Debian 11), I found that the load-tc358743-edid service fails at boot time, which causes uStreamer's capture to fail.

The ideal solution would be to find the service that needs to be up before the load-tc358743-edid service can succeed and then declare that in the After= line, but I haven't been able to identify which service that is.

As a workaround, we can add a retry count of 20 so that if we fail initially, we keep trying to start the service until it succeeds.