### PR TITLE
Make uStreamer depend explicitly on load-tc358743-edid service

### DIFF
--- a/templates/ustreamer.systemd.j2
+++ b/templates/ustreamer.systemd.j2
@@ -1,6 +1,6 @@
 [Unit]
 Description=uStreamer - Lightweight, optimized video encoder
-After=syslog.target network.target
+After=syslog.target network.target{% if ustreamer_capture_device == 'tc358743' %} load-tc358743-edid.service{% endif %}
 
 [Service]
 Type=simple


### PR DESCRIPTION
When the device is using a TC358743 capture chip (the common HDMI to CSI bridge), uStreamer depends on the load-tc358743-edid because it won't be able to capture video until the system has loaded the correct EDID for the chip.

We've never run into this issue on Debian Buster (Debian 10) because uStreamer depends on network.target, so it starts later than the load-tc358743-edid service. On Bullseye, it's possible for the load-tc358743-edid service to need several retries before starting successfully, so we want to make sure uStreamer doesn't start until the load-tc358743-edid service has finished.