### PR TITLE
Make uStreamer H264 check truthy rather than strict

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -5,7 +5,7 @@
     description: A lightweight, optimized video streaming service
     license: MIT
 
-    min_ansible_version: 2.8
+    min_ansible_version: 2.10
 
     platforms:
       - name: Debian

--- a/molecule/requirements.txt
+++ b/molecule/requirements.txt
@@ -8,7 +8,7 @@
 
 # Direct dependencies
 
-ansible==2.9.10
+ansible==2.10.7
 molecule==3.2.3
 molecule-docker==0.2.4
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -19,6 +19,9 @@
     - janus
     - systemd-config
   set_fact:
+    # We use is truthy rather than != None because there's a strange bug where
+    # if a parent role overrides this value with null, this role sees it as an
+    # empty string rather than null. We work around this by checking truthiness.
     ustreamer_install_janus: "{{ ustreamer_h264_sink is truthy }}"
 
 # If the `build uStreamer` step should be run with the `WITH_JANUS` option, we

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -19,7 +19,7 @@
     - janus
     - systemd-config
   set_fact:
-    ustreamer_install_janus: "{{ ustreamer_h264_sink != None }}"
+    ustreamer_install_janus: "{{ ustreamer_h264_sink is truthy }}"
 
 # If the `build uStreamer` step should be run with the `WITH_JANUS` option, we
 # need to install the Janus Debian package beforehand, because it provides


### PR DESCRIPTION
I've figured out a way to override ansible-role-ustreamer's default vars more elegantly than we've been using, and everything works except that `ustreamer_h264_sink` somehow gets converted from `null` to `''` when it passes the boundary between the parent role and ansible-role-ustreamer as a child role.

It would be better to dig into the root cause, but I've spent a few hours on this, and I'm not sure how much digging deeper would be worth it.

`is truthy` wasn't added until Ansible 2.10, so this bumps the min Ansible version to 2.10, which is what we're using in TinyPilot anyway.
<a data-ca-tag href="https://codeapprove.com/pr/tiny-pilot/ansible-role-ustreamer/70"><img src="https://codeapprove.com/external/github-tag-allbg.png" alt="Review on CodeApprove" /></a>