### PR TITLE
Add required audio packages for uStreamer with Janus

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -104,6 +104,13 @@
     ustreamer_packages: "{{ ustreamer_packages }} + ['libjpeg9-dev']"
   when: ustreamer_is_os_raspbian
 
+- name: collect Raspberry Pi OS specific required apt packages for audio
+  set_fact:
+    ustreamer_packages: "{{ ustreamer_packages }} + ['libasound2-dev', 'libspeex-dev', 'libspeexdsp-dev', 'libopus-dev']"
+  # Audio support is only possible in Raspbian 11 or higher, as audio was added
+  # in uStreamer 5.x, which requires Raspbian 11.
+  when: ustreamer_is_os_raspbian and ustreamer_install_janus and ((ansible_distribution_major_version | int) >= 11)
+
 - name: install libraspberrypi-dev if we're using OpenMax IL acceleration
   set_fact:
     ustreamer_packages: "{{ ustreamer_packages }} + ['libraspberrypi-dev']"


### PR DESCRIPTION
To support audio, uStreamer requires several additional audio packages. See https://github.com/pikvm/ustreamer/pull/184/commits/fd95bc51b4d5231a47fc2dab15ab1936a9d44e14
<a data-ca-tag href="https://codeapprove.com/pr/tiny-pilot/ansible-role-ustreamer/71"><img src="https://codeapprove.com/external/github-tag-allbg.png" alt="Review on CodeApprove" /></a>