### PR TITLE
Install Janus from `debian-backports`.

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -24,12 +24,51 @@
 # If the `build uStreamer` step should be run with the `WITH_JANUS` option, we
 # need to install the Janus Debian package beforehand, because it provides
 # C-headers.
+- name: add Debian archive apt repository key
+  apt_key:
+    url: https://ftp-master.debian.org/keys/archive-key-10.asc
+    state: present
+
+- name: enable buster-backports apt suite
+  apt_repository:
+    repo: deb http://deb.debian.org/debian buster-backports main
+    state: present
+
 - name: install Janus Debian package
   apt:
-    deb: "{{ ustreamer_janus_deb_file }}"
+    name:
+      - janus
+      - janus-dev
+    default_release: buster-backports
   tags:
     - janus
   when: ustreamer_install_janus
+
+# Allow Janus C header files to be included when compiling third-party plugins.
+# Issue: https://github.com/tiny-pilot/ansible-role-tinypilot/issues/192
+- name: patch Janus plugin.h file to successfully include refcount.h file
+  command: sed -i -e 's|^#include "refcount.h"$|#include "../refcount.h"|g' "/usr/include/janus/plugins/plugin.h"
+  when: ustreamer_install_janus
+
+- name: create Janus config
+  template:
+    src: janus.jcfg.j2
+    dest: "{{ ustreamer_janus_configs_dir }}/janus.jcfg"
+    owner: root
+    group: root
+    mode: '0644'
+  notify:
+    - restart Janus
+
+- name: create Janus websockets transport config
+  template:
+    src: janus.transport.websockets.jcfg.j2
+    dest: "{{ ustreamer_janus_configs_dir }}/janus.transport.websockets.jcfg"
+    owner: root
+    group: root
+    mode: '0644'
+  notify:
+    - restart Janus
 
 - name: create ustreamer group
   group:
@@ -224,7 +263,7 @@
 - name: create uStreamer Janus plugin config
   template:
     src: janus.plugin.ustreamer.jcfg.j2
-    dest: "{{ ustreamer_janus_install_dir }}/etc/janus/janus.plugin.ustreamer.jcfg"
+    dest: "{{ ustreamer_janus_configs_dir }}/janus.plugin.ustreamer.jcfg"
   notify:
     - restart Janus
   tags:
@@ -237,7 +276,7 @@
     # The `build uStreamer` step created and placed the `.so` file in case it
     # had been run with the `WITH_JANUS` option.
     src: "{{ ustreamer_dir }}/janus/libjanus_ustreamer.so"
-    dest: "{{ ustreamer_janus_install_dir }}/lib/janus/plugins/"
+    dest: "{{ ustreamer_janus_plugins_dir }}/"
   notify:
     - restart Janus
   tags:

--- a/templates/janus.jcfg.j2
+++ b/templates/janus.jcfg.j2
@@ -1,0 +1,11 @@
+plugins: {
+	disable = "libjanus_nosip.so,libjanus_videoroom.so,libjanus_streaming.so,libjanus_sip.so,libjanus_lua.so,libjanus_voicemail.so,libjanus_recordplay.so,libjanus_echotest.so,libjanus_audiobridge.so,libjanus_duktape.so,libjanus_videocall.so,libjanus_textroom.so"
+}
+
+transports: {
+	disable = "libjanus_rabbitmq.so,libjanus_pfunix.so,libjanus_nanomsg.so,libjanus_http.so"
+}
+
+loggers: {
+	disable = "libjanus_jsonlog.so"
+}

--- a/templates/janus.transport.websockets.jcfg.j2
+++ b/templates/janus.transport.websockets.jcfg.j2
@@ -1,0 +1,5 @@
+general: {
+    ws = true
+    ws_ip = "127.0.0.1"
+    ws_port = 8002
+}

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -3,5 +3,5 @@
 ustreamer_settings_file: /home/{{ ustreamer_user }}/config.yml
 
 # These variables are only used within this role.
-ustreamer_janus_deb_file: https://github.com/tiny-pilot/janus-debian/releases/download/1.0.1-20221104/janus_1.0.1-20221104_armhf.deb
-ustreamer_janus_install_dir: /opt/janus
+ustreamer_janus_configs_dir: /etc/janus
+ustreamer_janus_plugins_dir: /usr/lib/arm-linux-gnueabihf/janus/plugins


### PR DESCRIPTION
Resolves https://github.com/tiny-pilot/ansible-role-ustreamer/issues/77

I was able to successfully install Janus 0.9.2 from `debian-backports`. It seems to be working fine with TinyPilot end-to-end.

### Notes:

1. To build uStreamer `WITH_JANUS`, we need to expose the Janus C header files. We do this by installing [`janus-dev`](https://packages.debian.org/buster-backports/armhf/janus-dev/filelist). The Janus `plugins.h` file still suffers from [this bug](https://github.com/tiny-pilot/ansible-role-tinypilot/issues/192), so we needed to [patch it here](https://github.com/tiny-pilot/ansible-role-ustreamer/blob/f42d012e11ffa3bcaaf3c349c644ebeb7a5657e5/tasks/main.yml#L47-L51).
2. Janus installs all plugins, transports, and loggers by default. So we needed to [disable them here](https://github.com/tiny-pilot/ansible-role-ustreamer/blob/f42d012e11ffa3bcaaf3c349c644ebeb7a5657e5/templates/janus.jcfg.j2).
3. Notice the [default folder for plugins](https://github.com/tiny-pilot/ansible-role-ustreamer/blob/f42d012e11ffa3bcaaf3c349c644ebeb7a5657e5/vars/main.yml#L7), I'm sure this would change depending the architecture.