### PR TITLE
Fix molecule idempotence test.

### DIFF
--- a/tasks/install_janus.yml
+++ b/tasks/install_janus.yml
@@ -3,6 +3,7 @@
   shell: dpkg-query --show --showformat='${Maintainer}' janus | grep TinyPilot
   register: ustreamer_is_legacy_janus_installed
   ignore_errors: yes
+  changed_when: false
 
 - name: determine if legacy Janus package is installed
   set_fact:


### PR DESCRIPTION
This is needed to fix the `ansible-role-tinypilot` build in https://github.com/tiny-pilot/ansible-role-tinypilot/pull/240

I'm not too sure why the [idempotence molecule tests in this repo](https://github.com/tiny-pilot/ansible-role-ustreamer/blob/6584c655c6007127580972aeec3166e44ece29e5/molecule/default/molecule.yml#L38) didn't pick up this bug 🤔 