### PR TITLE
Drop support for Debian 9

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -11,6 +11,7 @@
       - name: Debian
         versions:
           - buster
+          - bullseye
       - name: Ubuntu
         versions:
           - groovy

--- a/molecule/legacy/molecule.yml
+++ b/molecule/legacy/molecule.yml
@@ -4,13 +4,6 @@ dependency:
 driver:
   name: docker
 platforms:
-  - name: debian9
-    image: geerlingguy/docker-debian9-ansible
-    command: ${MOLECULE_DOCKER_COMMAND:-""}
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:ro
-    privileged: true
-    pre_build_image: true
   - name: debian10
     image: geerlingguy/docker-debian10-ansible
     command: ${MOLECULE_DOCKER_COMMAND:-""}


### PR DESCRIPTION
We didn't advertise support for it, but we were testing it in CI. This drops support for Debian 9 because no Janus package is available on Debian 9, and there are no known Debian 9 consumers of this role.

We also adjust the meta/main.yml to accurately reflect support for both buster and bullseye versions of Debian (10, 11).
<a data-ca-tag href="https://codeapprove.com/pr/tiny-pilot/ansible-role-ustreamer/81"><img src="https://codeapprove.com/external/github-tag-allbg.png" alt="Review on CodeApprove" /></a>