### PR TITLE
Fix molecule to run the correct Ubuntu 20.04 image

### DIFF
--- a/molecule/legacy/molecule.yml
+++ b/molecule/legacy/molecule.yml
@@ -26,7 +26,7 @@ platforms:
     privileged: true
     pre_build_image: true
   - name: ubuntu20
-    image: geerlingguy/docker-ubuntu1804-ansible
+    image: geerlingguy/docker-ubuntu2004-ansible
     command: ${MOLECULE_DOCKER_COMMAND:-""}
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro


### PR DESCRIPTION
In our molecule test for ubuntu20, we were actually running an ubuntu18 image by mistake. This fixes it so that we're running an Ubuntu 20 image in the ubuntu20 test.