### PR TITLE
Add Janus plugin audio config.

### DIFF
--- a/templates/janus.plugin.ustreamer.jcfg.j2
+++ b/templates/janus.plugin.ustreamer.jcfg.j2
@@ -1,3 +1,10 @@
 memsink: {
     object = "{{ ustreamer_h264_sink }}"
 }
+
+{% if ustreamer_capture_device == 'tc358743' -%}
+audio: {
+    device = "hw:1"
+    tc358743 = "/dev/video0"
+}
+{% endif -%}


### PR DESCRIPTION
Resolves https://github.com/tiny-pilot/ansible-role-ustreamer/issues/73

This PR adds audio config to the Janus plugin if you're using a TC358743-based video capture device.

### Notes
1. We could replace the [static `/dev/video0` value](https://github.com/tiny-pilot/ansible-role-ustreamer/blob/096de5cdfb48308444e4b75a9cf44076b8c476f4/templates/janus.plugin.ustreamer.jcfg.j2#L8) with the dynamic `{{ ustreamer_video_path }}` variable. However, we currently don't set a [default value in our ansible variables](https://github.com/tiny-pilot/ansible-role-ustreamer/blob/096de5cdfb48308444e4b75a9cf44076b8c476f4/defaults/main.yml#L14-L15). Without arguments, ustreamer will open`/dev/video0`. If we do set a default value, then we will also need to read `ustreamer_video_path` from the ustreamer config file ([like we do for `ustreamer_capture_device `](https://github.com/tiny-pilot/ansible-role-ustreamer/blob/096de5cdfb48308444e4b75a9cf44076b8c476f4/tasks/check_saved_settings.yml#L13))

<a data-ca-tag href="https://codeapprove.com/pr/tiny-pilot/ansible-role-ustreamer/85"><img src="https://codeapprove.com/external/github-tag-allbg.png" alt="Review on CodeApprove" /></a>