### PR TITLE
Add `tc358743-audio` to boot config.

### DIFF
--- a/tasks/provision_tc358743.yml
+++ b/tasks/provision_tc358743.yml
@@ -6,17 +6,13 @@
     insertafter: EOF
   when: boot_config_exists | bool
 
+# Note that the tc358743-audio overlay depends on the tc358743 overlay.
 - name: enable TC358743-audio overlay in /boot/config.txt
   lineinfile:
     path: /boot/config.txt
     line: "dtoverlay=tc358743-audio"
     insertafter: EOF
-  # Technically, it's possible to use audio on Debian 10, but for simplicity,
-  # we assume only Raspbian/Debian 11 wants to use audio features.
-  when: >-
-    boot_config_exists
-    and (ustreamer_is_os_raspbian or ustreamer_is_os_debian)
-    and ((ansible_distribution_major_version | int) >= 11)
+  when: boot_config_exists and ustreamer_enable_audio_streaming
 
 - name: set GPU memory to 256MB in /boot/config.txt
   lineinfile:

--- a/tasks/provision_tc358743.yml
+++ b/tasks/provision_tc358743.yml
@@ -6,6 +6,18 @@
     insertafter: EOF
   when: boot_config_exists | bool
 
+- name: enable TC358743-audio overlay in /boot/config.txt
+  lineinfile:
+    path: /boot/config.txt
+    line: "dtoverlay=tc358743-audio"
+    insertafter: EOF
+  # Technically, it's possible to use audio on Debian 10, but for simplicity,
+  # we assume only Raspbian/Debian 11 wants to use audio features.
+  when: >-
+    boot_config_exists
+    and (ustreamer_is_os_raspbian or ustreamer_is_os_debian)
+    and ((ansible_distribution_major_version | int) >= 11)
+
 - name: set GPU memory to 256MB in /boot/config.txt
   lineinfile:
     path: /boot/config.txt

--- a/tasks/remove_tc358743.yml
+++ b/tasks/remove_tc358743.yml
@@ -12,3 +12,10 @@
     line: "dtoverlay=tc358743"
     state: absent
   when: boot_config_exists | bool
+
+- name: disable TC358743-audio overlay in /boot/config.txt
+  lineinfile:
+    path: /boot/config.txt
+    line: "dtoverlay=tc358743-audio"
+    state: absent
+  when: boot_config_exists | bool


### PR DESCRIPTION
Resolves https://github.com/tiny-pilot/ansible-role-ustreamer/issues/74

### Notes
1. [Here's confirmation](https://forums.raspberrypi.com/viewtopic.php?t=258742#p1577458) that `dtoverlay=tc358743-audio` must be added to `/boot/config.txt` and doesn't replace [`dtoverlay=tc358743`](https://github.com/tiny-pilot/ansible-role-ustreamer/blob/d60cb4884f951cca4678421d9a8f3f8e993ff8cd/tasks/provision_tc358743.yml#L2-L7)
2. From the tasks description:
    > We should use `when` conditions to ensure we don't add this to Raspbian Buster.
    
    I've maintained [this previous decision](https://github.com/tiny-pilot/ansible-role-ustreamer/blob/d60cb4884f951cca4678421d9a8f3f8e993ff8cd/tasks/main.yml#L110-L117) to simplify the conditions for supporting audio to Raspbian/Debian 11+
<a data-ca-tag href="https://codeapprove.com/pr/tiny-pilot/ansible-role-ustreamer/86"><img src="https://codeapprove.com/external/github-tag-allbg.png" alt="Review on CodeApprove" /></a>