### PR TITLE
Exercise Janus steps in molecule test

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -14,7 +14,7 @@
           - bullseye
       - name: Ubuntu
         versions:
-          - groovy
+          - jammy
 
     galaxy_tags:
       - raspberrypi

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -19,7 +19,7 @@
       include_role:
         name: "ansible-role-ustreamer"
       vars:
-        ustreamer_repo_version: "v5.23"
+        ustreamer_repo_version: "v5.34"
         # Assigning `ustreamer_h264_sink` will exercise the role tasks related
         # to installing and configuring the Janus WebRTC server.
         ustreamer_h264_sink: tinypilot::ustreamer::h264

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -20,3 +20,8 @@
         name: "ansible-role-ustreamer"
       vars:
         ustreamer_repo_version: "v5.23"
+        # Assigning `ustreamer_h264_sink` will exercise the role tasks related
+        # to installing and configuring the Janus WebRTC server.
+        ustreamer_h264_sink: tinypilot::ustreamer::h264
+        ustreamer_h264_sink_mode: 777
+        ustreamer_h264_sink_rm: yes

--- a/molecule/legacy/converge.yml
+++ b/molecule/legacy/converge.yml
@@ -20,3 +20,8 @@
         name: "ansible-role-ustreamer"
       vars:
         ustreamer_repo_version: "v4.13"
+        # Assigning `ustreamer_h264_sink` will exercise the role tasks related
+        # to installing and configuring the Janus WebRTC server.
+        ustreamer_h264_sink: tinypilot::ustreamer::h264
+        ustreamer_h264_sink_mode: 777
+        ustreamer_h264_sink_rm: yes

--- a/molecule/legacy/molecule.yml
+++ b/molecule/legacy/molecule.yml
@@ -18,8 +18,8 @@ platforms:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
     privileged: true
     pre_build_image: true
-  - name: ubuntu20
-    image: geerlingguy/docker-ubuntu2004-ansible
+  - name: ubuntu22
+    image: geerlingguy/docker-ubuntu2204-ansible
     command: ${MOLECULE_DOCKER_COMMAND:-""}
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro

--- a/molecule/legacy/molecule.yml
+++ b/molecule/legacy/molecule.yml
@@ -4,13 +4,6 @@ dependency:
 driver:
   name: docker
 platforms:
-  - name: debian9
-    image: geerlingguy/docker-debian9-ansible
-    command: ${MOLECULE_DOCKER_COMMAND:-""}
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:ro
-    privileged: true
-    pre_build_image: true
   - name: debian10
     image: geerlingguy/docker-debian10-ansible
     command: ${MOLECULE_DOCKER_COMMAND:-""}
@@ -26,7 +19,7 @@ platforms:
     privileged: true
     pre_build_image: true
   - name: ubuntu20
-    image: geerlingguy/docker-ubuntu1804-ansible
+    image: geerlingguy/docker-ubuntu2004-ansible
     command: ${MOLECULE_DOCKER_COMMAND:-""}
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -111,8 +111,9 @@
   # audio was added in uStreamer 5.x, which requires Raspbian 11.
   when: >-
     ustreamer_install_janus
-    and ustreamer_is_os_raspbian
-    and ((ansible_distribution_major_version | int) <= 10)
+    and not (
+      ustreamer_is_os_raspbian
+      and ((ansible_distribution_major_version | int) <= 10))
 
 - name: install libraspberrypi-dev if we're using OpenMax IL acceleration
   set_fact:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -31,6 +31,21 @@
     ustreamer_is_os_raspbian: "{{ ansible_lsb.id is defined and ansible_lsb.id == 'Raspbian' }}"
     ustreamer_is_os_debian: "{{ ansible_lsb.id is defined and ansible_lsb.id == 'Debian' }}"
 
+- name: decide whether to support audio streaming
+  set_fact:
+    # Audio streaming requires Janus because MJPEG can't carry audio.
+    # We exclude audio support from Raspbian Buster (10) because it's
+    # technically possible for a Raspbian Buster system to stream audio with CPU
+    # video encoding, it's unlikely for any clients to want that, and we don't
+    # want to add extra dependencies for audio they won't use. Raspbian Buster
+    # can't do GPU-based (OMX) encoding with audio because uStreamer added audio
+    # support in 5.x, but 5.x dropped support for OMX.
+    ustreamer_enable_audio_streaming: "{{
+      ustreamer_install_janus and not (
+        ustreamer_is_os_raspbian
+        and ((ansible_distribution_major_version | int) <= 10)
+      )}}"
+
 - name: install Janus
   include_tasks: install_janus.yml
   when: ustreamer_install_janus
@@ -107,13 +122,7 @@
 - name: collect Raspberry Pi OS and Debian specific required apt packages for audio
   set_fact:
     ustreamer_packages: "{{ ustreamer_packages }} + ['libasound2-dev', 'libspeex-dev', 'libspeexdsp-dev', 'libopus-dev']"
-  # On Raspbian, audio support is only possible in Raspbian 11 or higher, as
-  # audio was added in uStreamer 5.x, which requires Raspbian 11.
-  when: >-
-    ustreamer_install_janus
-    and not (
-      ustreamer_is_os_raspbian
-      and ((ansible_distribution_major_version | int) <= 10))
+  when: ustreamer_install_janus and ustreamer_enable_audio_streaming
 
 - name: install libraspberrypi-dev if we're using OpenMax IL acceleration
   set_fact:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -107,14 +107,12 @@
 - name: collect Raspberry Pi OS and Debian specific required apt packages for audio
   set_fact:
     ustreamer_packages: "{{ ustreamer_packages }} + ['libasound2-dev', 'libspeex-dev', 'libspeexdsp-dev', 'libopus-dev']"
-  # Audio support is only possible in Raspbian 11 or higher, as audio was added
-  # in uStreamer 5.x, which requires Raspbian 11. Technically, it's possible to
-  # use audio on Debian 10, but for simplicity, we assume only Raspbian/Debian
-  # 11 wants to use audio features.
+  # On Raspbian, audio support is only possible in Raspbian 11 or higher, as
+  # audio was added in uStreamer 5.x, which requires Raspbian 11.
   when: >-
     ustreamer_install_janus
-    and (ustreamer_is_os_raspbian or ustreamer_is_os_debian)
-    and ((ansible_distribution_major_version | int) >= 11)
+    and ustreamer_is_os_raspbian
+    and ((ansible_distribution_major_version | int) <= 10)
 
 - name: install libraspberrypi-dev if we're using OpenMax IL acceleration
   set_fact:

--- a/vars/Ubuntu.yml
+++ b/vars/Ubuntu.yml
@@ -1,2 +1,2 @@
 ---
-ustreamer_janus_apt_suite: stable
+ustreamer_janus_apt_suite: "{{ ansible_distribution_release }}"


### PR DESCRIPTION
Our tests have been skipping Janus installation, which creates a significant test gap given that Janus is a major dependency for uStreamer with H264.

This change adjusts our tests so that they exercise Janus and makes slight adjustments to the production code to avoid breaking Janus on non-Debian systems.

Note that we had to upgrade the test target from Ubuntu 20 to Ubuntu 22 because the Janus apt package for Ubuntu 22 was too old for uStreamer to build against.

<a data-ca-tag href="https://codeapprove.com/pr/tiny-pilot/ansible-role-ustreamer/87"><img src="https://codeapprove.com/external/github-tag-allbg.png" alt="Review on CodeApprove" /></a>