### PR TITLE
Install debian-archive-keyring

### DIFF
--- a/tasks/install_janus.yml
+++ b/tasks/install_janus.yml
@@ -18,6 +18,8 @@
 - name: install archive apt repository key
   apt:
     name: debian-archive-keyring
+    state: present
+  when: ustreamer_is_os_raspbian or ustreamer_is_os_debian
 
 - name: enable Janus apt suite
   apt_repository:

--- a/tasks/install_janus.yml
+++ b/tasks/install_janus.yml
@@ -15,15 +15,9 @@
     state: absent
   when: ustreamer_is_legacy_janus_installed
 
-- name: install apt_key dependency
+- name: install archive apt repository key
   apt:
-    name: gnupg
-
-- name: add archive apt repository key
-  apt_key:
-    url: https://ftp-master.debian.org/keys/archive-key-{{ ansible_distribution_major_version }}.asc
-    state: present
-  when: ustreamer_is_os_raspbian or ustreamer_is_os_debian
+    name: debian-archive-keyring
 
 - name: enable Janus apt suite
   apt_repository:


### PR DESCRIPTION
The ftp-master.debian.org just had an outage this weekend, so it seems risky to depend on that server directly. We can achieve the same result by installing the debian-archive-keyring package.

Reference: https://github.com/tiny-pilot/tinypilot/issues/1236
Reference: https://lists.debian.org/debian-infrastructure-announce/2022/12/msg00002.html

<a data-ca-tag href="https://codeapprove.com/pr/tiny-pilot/ansible-role-ustreamer/88"><img src="https://codeapprove.com/external/github-tag-allbg.png" alt="Review on CodeApprove" /></a>