### PR TITLE
Add a CI step to decode the EDID

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,7 +32,7 @@ jobs:
       - checkout
       - run:
           name: Install edid-decode
-          command: apt-get update && apt-get install edid-decode
+          command: sudo apt-get update && sudo apt-get install edid-decode
       - run:
           name: Decode the EDID
           command: tests/decode-edid

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,7 +32,7 @@ jobs:
       - checkout
       - run:
           name: Install edid-decode
-          command: sudo apt-get update && sudo apt-get install edid-decode
+          command: sudo apt-get update && sudo apt-get install --yes edid-decode
       - run:
           name: Decode the EDID
           command: tests/decode-edid

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,6 +24,18 @@ jobs:
       - run:
           name: Run static analysis on bash scripts
           command: ./tests/check-bash
+  decode_edid:
+    docker:
+      - image: cimg/base:2022.02
+    resource_class: small
+    steps:
+      - checkout
+      - run:
+          name: Install edid-decode
+          command: apt-get update && apt-get install edid-decode
+      - run:
+          name: Decode the EDID
+          command: tests/decode-edid
   build:
     parameters:
       scenario:
@@ -57,6 +69,7 @@ workflows:
     jobs:
       - check_whitespace
       - check_bash
+      - decode_edid
       - build:
           matrix:
             parameters:

--- a/tests/decode-edid
+++ b/tests/decode-edid
@@ -17,7 +17,7 @@ set -u
 # Extract the EDID from the inline YAML definition.
 grep "ustreamer_edid:" -A16 defaults/main.yml | \
   `# Strip the line with ustreamer_edid` \
-  tail -n +2 | \
-  `# Strip leading whitespace` \
-  awk '{$1=$1};1' | \
+  tail --lines=+2 | \
+  `# Strip whitespace` \
+  tr --delete "[:blank:]" | \
   edid-decode

--- a/tests/decode-edid
+++ b/tests/decode-edid
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+# Decode the EDID from the role defaults.
+
+# This script facilitates debugging the EDID and creates helpful logs of EDID
+# changes in CI.
+
+# Exit build script on first failure.
+set -e
+
+# Echo commands before executing them, by default to stderr.
+set -x
+
+# Exit on unset variable.
+set -u
+
+# Extract the EDID from the inline YAML definition.
+grep "ustreamer_edid:" -A16 defaults/main.yml | \
+  `# Strip the line with ustreamer_edid` \
+  tail -n +2 | \
+  `# Strip leading whitespace` \
+  awk '{$1=$1};1' | \
+  edid-decode


### PR DESCRIPTION
Resolves https://github.com/tiny-pilot/tinypilot/issues/1373

It's difficult to inspect source changes to the EDID, as we store it as a hex blob. This change improves inspection slightly by decoding the EDID and printing it to CI logs.
<a data-ca-tag href="https://codeapprove.com/pr/tiny-pilot/ansible-role-ustreamer/102"><img src="https://codeapprove.com/external/github-tag-allbg.png" alt="Review on CodeApprove" /></a>